### PR TITLE
#5 NestJS v9 이상 Logger 직접 확장 금지로 대신 ConsoleLogger 사용

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@nestjs/common": "^11.0.12",
+    "@nestjs/common": "11.0.12",
     "@nestjs/config": "^4.0.1",
-    "@nestjs/core": "^11.0.12",
+    "@nestjs/core": "11.0.12",
     "@nestjs/platform-express": "^11.0.12",
     "@nestjs/typeorm": "^11.0.0",
     "class-transformer": "^0.5.1",
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@nestjs/cli": "^7.0.0",
     "@nestjs/schematics": "^7.0.0",
-    "@nestjs/testing": "^7.0.0",
+    "@nestjs/testing": "11.0.12",
     "@types/express": "^4.17.3",
     "@types/jest": "^29.5.14",
     "@types/node": "^13.9.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,9 @@ import { ValidationPipe } from '@nestjs/common';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  //유효성 검사
   app.useGlobalPipes(new ValidationPipe({ transform: true }));
+  //CORS 활성화
   app.enableCors();
 
   await app.listen(3000);

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { AppModule } from './../src/app.module';
+import { AppModule } from '../src/app.module';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;


### PR DESCRIPTION
#5 
> [Nest] 65941  - 03/20/2025, 10:53:54 PM   ERROR Using the "extends Logger" instruction is not allowed in Nest v9. Please, use "extends ConsoleLogger" instead.

1. Logger 실제로 직접 작성한 코드 없음
@nestjs/common 등 패키지 버전 불일치해서 발생할 수 있다고함

> yarn add @nestjs/common@11.0.12 @nestjs/core@11.0.12 @nestjs/testing@11.0.12

* 패키지 캐시 삭제 후 재설치
//버전 충돌이 해결되지 않으면 의존성을 완전히 삭제 후 다시 설치.
```
rm -rf node_modules yarn.lock
yarn cache clean
yarn install

```
* yarn list로 패키지 버전 확인
```
yarn list @nestjs/common
yarn why @nestjs/common
````

*  Nest CLI
(특징)
 --watch 기능을 통해 코드 변경 시 자동 반영
 프로젝트를 빠르게 생성
 빌드, 실행, 테스트를 간편하게 실행
```
{
  "collection": "@nestjs/schematics", //
  "sourceRoot": "src" //NestJS 프로젝트의 소스 코드(.ts)가 위치하는 기본 디렉토리
}

```
> nest g controller users

@nestjs/schematics에 정의된 템플릿을 사용하여 src/users/users.controller.ts 파일을 자동 생성