### PR TITLE
#7 Dockerfile을 작성하고 로컬에서 Docker 이미지를 빌드한 후 컨테이너를 실행한다

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.git
+dist
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    container_name: nest-app
+    restart: always
+    ports:
+      - "3000:3000"
+    depends_on:
+      - mysql
+    env_file:
+        - .env  # .env 파일에서 환경변수 로드
+    networks:
+      - mynetwork
+
+  mysql:
+    image: mysql:8.0
+    container_name: mysql
+    restart: always
+    env_file:
+      - .env  # MySQL 서비스도 .env 사용
+    ports:
+      - "3306:3306"
+    command: --default-authentication-plugin=mysql_native_password  # 부팅 시 인증 방식을 구버전 호환 모드로 설정,NestJS, TypeORM, Node.js 앱을 MySQL 8과 연동할 때 거의 필수로 넣는 설정
+
+    networks:
+      - mynetwork
+
+networks:
+  mynetwork:
+    driver: bridge

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,7 +15,8 @@ import { ConfigModule } from '@nestjs/config';
       username: process.env.DATABASE_USER ,
       password: process.env.DATABASE_PASSWORD,
       database: process.env.DATABASE_NAME ,
-
+      synchronize: true ,// 자동 테이블 생성
+      autoLoadEntities: true, //자동 entity 등록
     }),
     TodoModule
   ]

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { AppModule } from './../src/app.module';
+import { AppModule } from '../src/app.module';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;


### PR DESCRIPTION
#7 
* docker-compose.yml → DB + 앱 한 번에 실행

* 사용 명령어
(mac) brew install docker-compose
docker compose version

* 이미지를 빌드하고 실행한다
docker compose build
docker compose down
docker compose up

* nest-app  | [Nest] 40  - 03/21/2025, 2:55:15 PM   ERROR [ExceptionsHandler] QueryFailedError: ER_NO_SUCH_TABLE: Table 'todo_db.todo' doesn't exist
todo 테이블이 없음
`synchronize: true로 자동 테이블 생성`

`-p 3000:3000 ` 
내 PC(호스트)의 3000번 포트를 → 컨테이너의 3000번 포트로 연결
`http://localhost:3000`
`GET http://localhost:3000/todos`

* post 데이터 추가
>  curl 명령어로 post
curl -X POST http://localhost:3000/todos \
  -H "Content-Type: application/json" \
  -d '{"title": "NestJS 공부하기"}'

컨테이너 안에 2개 이미지를 생성하고 실행했어

MySQL 컨태이너 이름을 확인하거나 직접 들어간다
`docker exec -it mysql bash`
컨테이너 안에서 아래 명령으로 MySQL에 로그인
`mysql -u root -p`
`USE todo_db;`
`SHOW TABLES;`

Database changed
mysql> SHOW TABLES;
+-------------------+
| Tables_in_todo_db |
+-------------------+
| todo              |
+-------------------+
1 row in set (0.00 sec)


*용어
 컨테이너  이미지가 실행된 인스턴스